### PR TITLE
fix: improve AP signal stability for ESP32-C3 PCB antenna boards

### DIFF
--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -4,6 +4,7 @@
 
 #include <Arduino.h>
 #include <WiFi.h>
+#include <esp_wifi.h>
 #include <ESPAsyncWebServer.h>
 #include <U8g2lib.h>
 #include <Wire.h>
@@ -80,6 +81,17 @@ void setup() {
             xEventGroupClearBits(connectivityBits, WIFI_CONNECTED_BIT);
         }
     });
+
+    // WiFi AP stability fix for ESP32-C3 PCB antenna (fixes #2):
+    // Force AP mode before NetWizard starts to ensure stable beacons.
+    // Reduce TX power to avoid signal distortion on small PCB antenna.
+    // Set HT20 (20 MHz) bandwidth for better client compatibility.
+    // NetWizard will switch to AP_STA/STA internally when connecting to saved WiFi.
+    WiFi.mode(WIFI_AP);
+    WiFi.setTxPower(WIFI_POWER_13dBm);
+    esp_wifi_set_bandwidth(WIFI_IF_AP, WIFI_BW_HT20);
+    WiFi.softAPConfig(IPAddress(192,168,4,1), IPAddress(192,168,4,1), IPAddress(255,255,255,0));
+    WiFi.softAP("QBIT", apPwd.c_str(), 1, 0, 4);
 
     NW.setStrategy(NetWizardStrategy::NON_BLOCKING);
     NW.autoConnect("QBIT", apPwd.c_str());


### PR DESCRIPTION
Fixes #2

## Problem
On ESP32-C3 boards with a small PCB antenna (e.g. Super Mini), the QBIT
Wi-Fi AP either doesn't appear or is too weak to connect to. This is caused
by RF interference between the antenna and the crystal oscillator on these
compact boards.

## Root Cause
- `WiFi.mode(WIFI_AP_STA)` (set internally by NetWizard) time-shares the
  single radio between AP and STA, making AP beacons unreliable
- Default TX power is too high for small PCB antennas, causing signal
  distortion
- Default HT40 (40 MHz) bandwidth reduces compatibility with some devices

## Fix
- Set `WiFi.mode(WIFI_AP)` before `NW.autoConnect()` so the AP starts with
  a dedicated radio (NetWizard switches mode internally when connecting to
  saved Wi-Fi)
- Reduce TX power to `WIFI_POWER_13dBm` to prevent signal distortion
- Set HT20 (20 MHz) bandwidth via `esp_wifi_set_bandwidth()` for better
  client compatibility
- Explicit `softAPConfig()` and `softAP()` with channel 1 for maximum
  compatibility

## Tested on
- ESP32-C3 (Super Mini variant)