### PR TITLE
feat: add Flappy Bird game implementation and integrate into game menu

### DIFF
--- a/firmware/src/app_state.h
+++ b/firmware/src/app_state.h
@@ -33,7 +33,9 @@ enum DisplayState {
     TIMER_SET,
     TIMER_RUNNING,
     GAME_RUNNING,
-    GAME_OVER
+    GAME_OVER,
+    FLAPPY_RUNNING,
+    FLAPPY_OVER
 };
 
 // ==========================================================================

--- a/firmware/src/display_task.cpp
+++ b/firmware/src/display_task.cpp
@@ -15,6 +15,7 @@
 #include "timer_ui.h"
 #include "game_menu.h"
 #include "game_runner.h"
+#include "flappy_bird.h"
 
 #include "gif_types.h"
 #include "sys_scx.h"
@@ -543,6 +544,7 @@ void displayTask(void *param) {
         if (xQueueReceive(gestureQueue, &gesture, 0) == pdTRUE) {
             // Publish to MQTT only when not in game; never publish touch_down/touch_up (low-level press/release)
             if (_state != GAME_RUNNING && _state != GAME_OVER &&
+                _state != FLAPPY_RUNNING && _state != FLAPPY_OVER &&
                 gesture.type != TOUCH_DOWN && gesture.type != TOUCH_UP)
                 mqttPublishTouchEvent(gesture.type);
 
@@ -778,6 +780,11 @@ void displayTask(void *param) {
                             gameRunnerEnter();
                             enterState(GAME_RUNNING);
                             gameRunnerDrawFrame();
+                        } else if (ma == GameMenuAction::Launch1) {
+                            updateAvailable = false;
+                            flappyEnter();
+                            enterState(FLAPPY_RUNNING);
+                            flappyDrawFrame();
                         } else if (ma == GameMenuAction::OpenContribute) {
                             enterState(GAME_CONTRIBUTE);
                             drawContributeScreen();
@@ -866,6 +873,35 @@ void displayTask(void *param) {
                         gameRunnerEnter();
                         enterState(GAME_RUNNING);
                         gameRunnerDrawFrame();
+                    } else if (gesture.type == LONG_PRESS) {
+                        enterState(GIF_PLAYBACK);
+                    }
+                    break;
+
+                case FLAPPY_RUNNING: {
+                    FlappyGestureType fg = FlappyGestureType::None;
+                    if (gesture.type == TOUCH_UP)    fg = FlappyGestureType::TouchUp;
+                    else if (gesture.type == TOUCH_DOWN)  fg = FlappyGestureType::TouchDown;
+                    else if (gesture.type == SINGLE_TAP)  fg = FlappyGestureType::SingleTap;
+                    else if (gesture.type == DOUBLE_TAP)  fg = FlappyGestureType::DoubleTap;
+                    else if (gesture.type == LONG_PRESS)  fg = FlappyGestureType::LongPress;
+                    FlappyAction fa = flappyOnGesture(fg);
+                    if (fa == FlappyAction::Flap) {
+                        flappyApplyFlap();
+                        if (getBuzzerVolume() > 0) {
+                            noTone(getPinBuzzer());
+                            rtttl::begin(getPinBuzzer(), TOUCH_MELODY);
+                        }
+                    }
+                    break;
+                }
+
+                case FLAPPY_OVER:
+                    if (now - _stateEntryMs < 1500) break;
+                    if (gesture.type == SINGLE_TAP) {
+                        flappyEnter();
+                        enterState(FLAPPY_RUNNING);
+                        flappyDrawFrame();
                     } else if (gesture.type == LONG_PRESS) {
                         enterState(GIF_PLAYBACK);
                     }
@@ -1130,6 +1166,23 @@ void displayTask(void *param) {
                 break;
 
             case GAME_OVER:
+                // Idle — waiting for gesture
+                break;
+
+            case FLAPPY_RUNNING:
+                flappyDrawFrame(now);
+                if (flappyTick(now)) {
+                    setFlappyHighScore(flappyGetScore());
+                    if (getBuzzerVolume() > 0) {
+                        noTone(getPinBuzzer());
+                        rtttl::begin(getPinBuzzer(), MUTE_MELODY);
+                    }
+                    enterState(FLAPPY_OVER);
+                    flappyDrawGameOver();
+                }
+                break;
+
+            case FLAPPY_OVER:
                 // Idle — waiting for gesture
                 break;
 

--- a/firmware/src/flappy_bird.cpp
+++ b/firmware/src/flappy_bird.cpp
@@ -1,0 +1,366 @@
+// ==========================================================================
+//  QBIT -- Flappy Bird game implementation
+//  Display: 128x64 OLED, rotated 180° via rotateBuffer180().
+//  Tap/TouchUp = flap upward. Avoid pipes and floor.
+// ==========================================================================
+#include "flappy_bird.h"
+#include "app_state.h"
+#include "display_helpers.h"
+#include "settings.h"
+#include <stdio.h>
+
+// --------------------------------------------------------------------------
+//  Constants
+// --------------------------------------------------------------------------
+#define FB_SCREEN_W        128
+#define FB_SCREEN_H        64
+#define FB_GROUND_Y        62      // Y of the ground line (drawn as a line)
+
+#define FB_BIRD_X          18      // fixed left-edge X of bird sprite
+#define FB_BIRD_W          8       // sprite width
+#define FB_BIRD_H          6       // sprite height (rows 0-5)
+
+// Collision box (inner padding to keep game fair but forgiving)
+#define FB_HIT_L           2       // left padding inside bird sprite
+#define FB_HIT_R           2       // right padding inside bird sprite
+#define FB_HIT_T           1       // top padding inside bird sprite
+#define FB_HIT_B           1       // bottom padding inside bird sprite
+
+#define FB_PIPE_W          10      // pipe body width
+#define FB_PIPE_GAP        18      // vertical opening height
+#define FB_PIPE_CAP_H      3       // pipe cap height (drawn at gap edge)
+#define FB_PIPE_CAP_EXT    1       // cap extends 1 px each side
+
+#define FB_MIN_GAP_TOP     10      // minimum Y for top of gap
+#define FB_MAX_GAP_TOP     35      // maximum Y for top of gap
+#define FB_PIPE_SPACING    68      // horizontal distance between pipe pairs
+#define FB_PIPE_OFFSCREEN  (-(FB_PIPE_W + FB_PIPE_CAP_EXT + 1))
+
+#define FB_TICK_MS         40      // ms per game tick (~25 fps)
+#define FB_FLAP_VEL4       (-20)   // upward launch velocity (×4 sub-pixel)
+#define FB_GRAVITY4        3       // gravity added to velY each tick (×4)
+#define FB_TERM_VEL4       22      // terminal downward velocity (×4)
+
+#define FB_SPEED_INIT      2       // initial pipe scroll speed (px/tick)
+#define FB_SPEED_MAX       5       // maximum pipe scroll speed
+#define FB_SPEEDUP_PIPES   8       // speed-up every N pipes scored
+
+// --------------------------------------------------------------------------
+//  Types
+// --------------------------------------------------------------------------
+struct FlappyPipe {
+    int16_t x;
+    int16_t gapTop;   // Y where the gap begins (top pipe ends just above)
+    bool    scored;
+};
+
+// --------------------------------------------------------------------------
+//  State
+// --------------------------------------------------------------------------
+static int16_t       _birdY4    = 0;   // bird top Y × 4 (sub-pixel)
+static int16_t       _velY4     = 0;
+static bool          _dead      = false;
+static uint8_t       _birdFrame = 0;   // 0=mid, 1=up, 2=down
+static uint8_t       _animTick  = 0;
+static uint32_t      _score     = 0;
+static uint8_t       _speed     = FB_SPEED_INIT;
+static unsigned long _lastTickMs = 0;
+static FlappyPipe    _pipes[2];
+static uint16_t      _randState = 1;
+
+// --------------------------------------------------------------------------
+//  Simple XOR-shift RNG (same pattern as game_runner.cpp)
+// --------------------------------------------------------------------------
+static uint16_t fbRand() {
+    if (_randState == 0) _randState = 1;
+    _randState ^= _randState << 7;
+    _randState ^= _randState >> 9;
+    _randState ^= _randState << 8;
+    return _randState;
+}
+
+// --------------------------------------------------------------------------
+//  Bird sprite
+//  8 columns wide × 6 rows tall.
+//  Each byte = one row; bit 7 = leftmost pixel (col 0), bit 0 = rightmost (col 7).
+//  Bird faces right: beak is the rightmost lit pixel on row 3.
+//  Eye hole: col 5 on row 2 is 0 (transparent).
+// --------------------------------------------------------------------------
+//  Col:  0 1 2 3 4 5 6 7
+//  Row0: . . X X X . . .   0x38
+//  Row1: . X X X X X . .   0x7C
+//  Row2: X X X X X . X .   0xFA  ← eye hole at col 5
+//  Row3: X X X X X X X X   0xFF  ← beak at col 7 (rightmost)
+//  Row4: . X X X X X X .   0x7E
+//  Row5: . . X X X X . .   0x3C
+static const uint8_t BIRD_BODY[6] = { 0x38, 0x7C, 0xFA, 0xFF, 0x7E, 0x3C };
+
+static void drawBird(int16_t bx, int16_t topY, uint8_t frame, bool dead) {
+    u8g2.setDrawColor(1);
+
+    // Draw body rows
+    for (int8_t r = 0; r < FB_BIRD_H; r++) {
+        int16_t sy = topY + r;
+        if (sy < 0 || sy > 63) continue;
+        uint8_t bits = BIRD_BODY[r];
+        for (int8_t c = 0; c < FB_BIRD_W; c++) {
+            if (bits & (0x80 >> c)) {
+                int16_t sx = bx + c;
+                if (sx >= 0 && sx <= 127)
+                    u8g2.drawPixel((uint8_t)sx, (uint8_t)sy);
+            }
+        }
+    }
+
+    if (dead) {
+        // X eyes: replace normal eye with × mark
+        u8g2.setDrawColor(0);
+        u8g2.drawPixel(bx + 5, topY + 2);  // clear body pixel at eye
+        u8g2.setDrawColor(1);
+        // × pattern around col 5, row 2
+        if (topY + 1 >= 0  && topY + 1 <= 63) {
+            if (bx + 4 >= 0 && bx + 4 <= 127) u8g2.drawPixel(bx + 4, topY + 1);
+            if (bx + 6 >= 0 && bx + 6 <= 127) u8g2.drawPixel(bx + 6, topY + 1);
+        }
+        if (topY + 3 >= 0 && topY + 3 <= 63) {
+            if (bx + 4 >= 0 && bx + 4 <= 127) u8g2.drawPixel(bx + 4, topY + 3);
+            if (bx + 6 >= 0 && bx + 6 <= 127) u8g2.drawPixel(bx + 6, topY + 3);
+        }
+    } else {
+        // Wing row: 3-pixel strip outside the body
+        if (frame == 1) {
+            // Wing up: one row above body
+            int16_t wy = topY - 1;
+            if (wy >= 0 && wy <= 63) {
+                for (int8_t c = 1; c <= 3; c++) {
+                    int16_t sx = bx + c;
+                    if (sx >= 0 && sx <= 127) u8g2.drawPixel((uint8_t)sx, (uint8_t)wy);
+                }
+            }
+        } else if (frame == 2) {
+            // Wing down: one row below body
+            int16_t wy = topY + FB_BIRD_H;
+            if (wy >= 0 && wy <= 63) {
+                for (int8_t c = 1; c <= 3; c++) {
+                    int16_t sx = bx + c;
+                    if (sx >= 0 && sx <= 127) u8g2.drawPixel((uint8_t)sx, (uint8_t)wy);
+                }
+            }
+        }
+        // frame 0: wing mid (no extra pixels — wing is folded)
+    }
+}
+
+// --------------------------------------------------------------------------
+//  Pipe drawing
+//  Top pipe:    body y=0..gapTop-CAP_H-1, cap y=gapTop-CAP_H..gapTop-1 (wider)
+//  Bottom pipe: cap y=gapTop+GAP..gapTop+GAP+CAP_H-1, body below that
+// --------------------------------------------------------------------------
+static void drawPipe(const FlappyPipe &p) {
+    int16_t px   = p.x;
+    int16_t capX = px - FB_PIPE_CAP_EXT;
+    int16_t capW = FB_PIPE_W + 2 * FB_PIPE_CAP_EXT;
+    int16_t gapBottom = p.gapTop + FB_PIPE_GAP;
+
+    // Clip helper (clips x/w to [0, 128))
+    auto drawClippedBox = [](int16_t bx, int16_t by, int16_t bw, int16_t bh) {
+        if (by < 0) { bh += by; by = 0; }
+        if (bh <= 0 || by >= 64) return;
+        if (bh > 64 - by) bh = 64 - by;
+        if (bx < 0) { bw += bx; bx = 0; }
+        if (bw <= 0 || bx >= 128) return;
+        if (bw > 128 - bx) bw = 128 - bx;
+        u8g2.drawBox((uint8_t)bx, (uint8_t)by, (uint8_t)bw, (uint8_t)bh);
+    };
+
+    u8g2.setDrawColor(1);
+
+    // Top pipe body (y = 0 to gapTop - CAP_H - 1)
+    {
+        int16_t bodyH = p.gapTop - FB_PIPE_CAP_H;
+        if (bodyH > 0)
+            drawClippedBox(px, 0, FB_PIPE_W, bodyH);
+    }
+    // Top pipe cap (y = gapTop - CAP_H to gapTop - 1)
+    drawClippedBox(capX, p.gapTop - FB_PIPE_CAP_H, capW, FB_PIPE_CAP_H);
+
+    // Bottom pipe cap (y = gapBottom to gapBottom + CAP_H - 1)
+    drawClippedBox(capX, gapBottom, capW, FB_PIPE_CAP_H);
+    // Bottom pipe body (y = gapBottom + CAP_H to 63)
+    {
+        int16_t bodyY = gapBottom + FB_PIPE_CAP_H;
+        int16_t bodyH = 64 - bodyY;
+        if (bodyH > 0)
+            drawClippedBox(px, bodyY, FB_PIPE_W, bodyH);
+    }
+}
+
+// --------------------------------------------------------------------------
+//  Spawn a pipe at the given x position
+// --------------------------------------------------------------------------
+static void spawnPipe(FlappyPipe &p, int16_t startX) {
+    uint16_t r = fbRand();
+    p.x       = startX;
+    p.gapTop  = FB_MIN_GAP_TOP + (int16_t)(r % (uint16_t)(FB_MAX_GAP_TOP - FB_MIN_GAP_TOP + 1));
+    p.scored  = false;
+}
+
+// --------------------------------------------------------------------------
+//  Public API
+// --------------------------------------------------------------------------
+
+void flappyEnter() {
+    _randState  = (uint16_t)(millis() & 0xFFFF) | 1;
+    _birdY4     = 27 * 4;   // bird top at Y=27, center ≈ Y=30
+    _velY4      = 0;
+    _dead       = false;
+    _birdFrame  = 0;
+    _animTick   = 0;
+    _score      = 0;
+    _speed      = FB_SPEED_INIT;
+    _lastTickMs = millis();
+    // First pipe spawns far enough right so player has time to react
+    spawnPipe(_pipes[0], 140);
+    spawnPipe(_pipes[1], 140 + FB_PIPE_SPACING);
+}
+
+void flappyDrawFrame(unsigned long /*nowMs*/) {
+    u8g2.clearBuffer();
+    u8g2.setDrawColor(1);
+
+    // HUD: high score and current score
+    {
+        char hud[22];
+        snprintf(hud, sizeof(hud), "HI %03lu  %03lu",
+                 (unsigned long)getFlappyHighScore(), (unsigned long)_score);
+        u8g2.setFont(u8g2_font_6x10_tr);
+        uint8_t hudW = u8g2.getStrWidth(hud);
+        u8g2.drawStr((int16_t)(128 - hudW - 2), 10, hud);
+    }
+
+    // Pipes
+    for (uint8_t i = 0; i < 2; i++)
+        drawPipe(_pipes[i]);
+
+    // Ground line
+    u8g2.drawHLine(0, FB_GROUND_Y, 128);
+
+    // Bird
+    int16_t birdTopY = _birdY4 / 4;
+    drawBird(FB_BIRD_X, birdTopY, _birdFrame, _dead);
+
+    rotateBuffer180();
+    u8g2.sendBuffer();
+}
+
+void flappyDrawGameOver() {
+    u8g2.clearBuffer();
+    u8g2.setFont(u8g2_font_6x13_tr);
+
+    const char *hdr = "[ Flappy Bird ]";
+    u8g2.drawStr((128 - u8g2.getStrWidth(hdr)) / 2, 13, hdr);
+
+    char scoreLine[20], bestLine[20];
+    snprintf(scoreLine, sizeof(scoreLine), "Score: %03lu", (unsigned long)_score);
+    snprintf(bestLine,  sizeof(bestLine),  "Best:  %03lu", (unsigned long)getFlappyHighScore());
+    u8g2.drawStr((128 - u8g2.getStrWidth(scoreLine)) / 2, 32, scoreLine);
+    u8g2.drawStr((128 - u8g2.getStrWidth(bestLine))  / 2, 46, bestLine);
+
+    const char *hint = "TAP=retry  HOLD=exit";
+    u8g2.drawStr((128 - u8g2.getStrWidth(hint)) / 2, 62, hint);
+
+    rotateBuffer180();
+    u8g2.sendBuffer();
+}
+
+FlappyAction flappyOnGesture(FlappyGestureType g) {
+    if (g == FlappyGestureType::TouchUp) return FlappyAction::Flap;
+    if (g == FlappyGestureType::SingleTap) return FlappyAction::Flap;
+    return FlappyAction::None;
+}
+
+void flappyApplyFlap() {
+    if (_dead) return;
+    _velY4     = FB_FLAP_VEL4;
+    _birdFrame = 1;   // wing up
+    _animTick  = 0;
+}
+
+bool flappyTick(unsigned long nowMs) {
+    if (nowMs - _lastTickMs < FB_TICK_MS) return false;
+    _lastTickMs = nowMs;
+
+    if (_dead) return false;
+
+    // --- Physics ---
+    _birdY4 += _velY4;
+    _velY4  += FB_GRAVITY4;
+    if (_velY4 > FB_TERM_VEL4) _velY4 = FB_TERM_VEL4;
+
+    // Ceiling: clamp and stop vertical velocity
+    if (_birdY4 < 0) { _birdY4 = 0; _velY4 = 0; }
+
+    int16_t birdTopY = _birdY4 / 4;
+    int16_t birdBotY = birdTopY + FB_BIRD_H - 1;
+
+    // Floor collision
+    if (birdBotY >= FB_GROUND_Y) {
+        _dead = true;
+        return true;
+    }
+
+    // --- Scroll pipes ---
+    for (uint8_t i = 0; i < 2; i++) {
+        _pipes[i].x -= _speed;
+
+        // Respawn pipe when it exits left edge
+        if (_pipes[i].x < FB_PIPE_OFFSCREEN) {
+            int16_t other = (i == 0) ? _pipes[1].x : _pipes[0].x;
+            int16_t spawnX = other + FB_PIPE_SPACING;
+            if (spawnX < 130) spawnX = 130;
+            spawnPipe(_pipes[i], spawnX);
+        }
+
+        // Score: pipe fully passes birgd X
+        if (!_pipes[i].scored && (_pipes[i].x + FB_PIPE_W) < FB_BIRD_X) {
+            _pipes[i].scored = true;
+            _score++;
+            if (_speed < FB_SPEED_MAX && (_score % FB_SPEEDUP_PIPES) == 0)
+                _speed++;
+        }
+    }
+
+    // --- Pipe collision ---
+    // Collision box (inner-padded for fairness)
+    int16_t hitLeft  = FB_BIRD_X + FB_HIT_L;
+    int16_t hitRight = FB_BIRD_X + FB_BIRD_W - 1 - FB_HIT_R;
+    int16_t hitTop   = birdTopY + FB_HIT_T;
+    int16_t hitBot   = birdBotY - FB_HIT_B;
+
+    for (uint8_t i = 0; i < 2; i++) {
+        const FlappyPipe &p = _pipes[i];
+        int16_t pLeft  = p.x;
+        int16_t pRight = p.x + FB_PIPE_W - 1;
+
+        // Horizontal overlap?
+        if (hitRight < pLeft || hitLeft > pRight) continue;
+
+        // Vertical: is bird's hit-box entirely inside the gap?
+        int16_t gapBottom = p.gapTop + FB_PIPE_GAP;
+        if (hitTop < p.gapTop || hitBot >= gapBottom) {
+            _dead = true;
+            return true;
+        }
+    }
+
+    // --- Animation ---
+    _animTick++;
+    if (_animTick >= 4) {
+        _animTick  = 0;
+        _birdFrame = (_birdFrame + 1) % 3;
+    }
+
+    return false;
+}
+
+uint32_t flappyGetScore() { return _score; }

--- a/firmware/src/flappy_bird.cpp
+++ b/firmware/src/flappy_bird.cpp
@@ -321,7 +321,7 @@ bool flappyTick(unsigned long nowMs) {
             spawnPipe(_pipes[i], spawnX);
         }
 
-        // Score: pipe fully passes birgd X
+        // Score: pipe fully passes bird X
         if (!_pipes[i].scored && (_pipes[i].x + FB_PIPE_W) < FB_BIRD_X) {
             _pipes[i].scored = true;
             _score++;

--- a/firmware/src/flappy_bird.h
+++ b/firmware/src/flappy_bird.h
@@ -1,0 +1,38 @@
+// ==========================================================================
+//  QBIT -- Flappy Bird (128x64, tap to flap through pipe gaps)
+// ==========================================================================
+#ifndef FLAPPY_BIRD_H
+#define FLAPPY_BIRD_H
+
+#include <Arduino.h>
+
+enum class FlappyGestureType {
+    None, TouchDown, TouchUp, SingleTap, DoubleTap, LongPress
+};
+
+enum class FlappyAction {
+    None, Flap, Exit
+};
+
+// Reset state and spawn first pipes. Call before entering FLAPPY_RUNNING.
+void flappyEnter();
+
+// Draw current frame (score, pipes, bird). nowMs is kept for API consistency.
+void flappyDrawFrame(unsigned long nowMs = 0);
+
+// Draw game over screen (score + best). Call after entering FLAPPY_OVER.
+void flappyDrawGameOver();
+
+// Run one game tick (physics, pipes, collision). Returns true if game over.
+bool flappyTick(unsigned long nowMs);
+
+// Current score (read after flappyTick() returns true before saving high score).
+uint32_t flappyGetScore();
+
+// Handle gesture during play. Returns Flap to trigger a flap.
+FlappyAction flappyOnGesture(FlappyGestureType g);
+
+// Apply flap impulse (call when OnGesture returns Flap).
+void flappyApplyFlap();
+
+#endif // FLAPPY_BIRD_H

--- a/firmware/src/flappy_bird.h
+++ b/firmware/src/flappy_bird.h
@@ -11,7 +11,7 @@ enum class FlappyGestureType {
 };
 
 enum class FlappyAction {
-    None, Flap, Exit
+    None, Flap
 };
 
 // Reset state and spawn first pipes. Call before entering FLAPPY_RUNNING.

--- a/firmware/src/game_menu.cpp
+++ b/firmware/src/game_menu.cpp
@@ -8,9 +8,10 @@
 
 static const char *GAME_MENU_LABELS[] = {
     "T-Rex Runner",
+    "Flappy Bird",
     "More games",
 };
-static const uint8_t GAME_MENU_COUNT_VAL = 2;
+static const uint8_t GAME_MENU_COUNT_VAL = 3;
 
 static uint8_t _cursor = 0;
 
@@ -63,7 +64,8 @@ GameMenuAction gameMenuOnGesture(GameMenuGestureType g) {
     }
     if (g == GameMenuGestureType::LongPress) {
         if (_cursor == 0) return GameMenuAction::Launch0;
-        if (_cursor == 1) return GameMenuAction::OpenContribute;
+        if (_cursor == 1) return GameMenuAction::Launch1;
+        if (_cursor == 2) return GameMenuAction::OpenContribute;
         return GameMenuAction::None;
     }
     if (g == GameMenuGestureType::DoubleTap)

--- a/firmware/src/game_menu.h
+++ b/firmware/src/game_menu.h
@@ -11,11 +11,12 @@ enum class GameMenuGestureType {
 };
 
 enum class GameMenuAction {
-    None,          // no action or redraw already done
-    Scroll,        // cursor moved (caller redraws)
-    Launch0,       // launch game index 0 (T-Rex Runner)
+    None,           // no action or redraw already done
+    Scroll,         // cursor moved (caller redraws)
+    Launch0,        // launch game index 0 (T-Rex Runner)
+    Launch1,        // launch game index 1 (Flappy Bird)
     OpenContribute, // open "contribute" hint (fake "More games" item)
-    Back           // return to settings
+    Back            // return to settings
 };
 
 // Reset cursor to 0. Call when entering GAME_MENU.

--- a/firmware/src/settings.cpp
+++ b/firmware/src/settings.cpp
@@ -50,7 +50,8 @@ static String  _tzIANA;
 static bool _flipMode        = true;
 
 // Game high score
-static uint32_t _gameHighScore = 0;
+static uint32_t _gameHighScore  = 0;
+static uint32_t _flappyHighScore = 0;
 static bool _negativeGif     = false;
 
 // Time format: true = 24h, false = 12h
@@ -152,7 +153,8 @@ void loadSettings() {
     _flipMode      = _prefs.getBool("flipMode",  true);
     _negativeGif   = _prefs.getBool("negGif",    false);
     _timeFormat24h = _prefs.getBool("time24h",   true);
-    _gameHighScore = _prefs.getUInt("gameHi",    0);
+    _gameHighScore   = _prefs.getUInt("gameHi",    0);
+    _flappyHighScore  = _prefs.getUInt("flappyHi",  0);
     xSemaphoreGive(_prefsMutex);
 
     // Apply speed
@@ -191,6 +193,7 @@ void saveSettings() {
     _prefs.putBool("negGif",     _negativeGif);
     _prefs.putBool("time24h",    _timeFormat24h);
     _prefs.putUInt("gameHi",     _gameHighScore);
+    _prefs.putUInt("flappyHi",   _flappyHighScore);
     xSemaphoreGive(_prefsMutex);
     Serial.println("Settings saved to NVS");
 }
@@ -302,9 +305,20 @@ uint32_t getGameHighScore()          { return _gameHighScore; }
 void     setGameHighScore(uint32_t s) {
     if (s > _gameHighScore) {
         _gameHighScore = s;
-        // Persist immediately so it survives power-off
         if (_prefsReady && xSemaphoreTake(_prefsMutex, portMAX_DELAY) == pdTRUE) {
             _prefs.putUInt("gameHi", _gameHighScore);
+            xSemaphoreGive(_prefsMutex);
+        }
+    }
+}
+// Flappy Bird high score
+uint32_t getFlappyHighScore()           { return _flappyHighScore; }
+void     setFlappyHighScore(uint32_t s) {
+    if (s > _flappyHighScore) {
+        _flappyHighScore = s;
+        // Persist immediately so it survives power-off
+        if (_prefsReady && xSemaphoreTake(_prefsMutex, portMAX_DELAY) == pdTRUE) {
+            _prefs.putUInt("flappyHi", _flappyHighScore);
             xSemaphoreGive(_prefsMutex);
         }
     }

--- a/firmware/src/settings.h
+++ b/firmware/src/settings.h
@@ -75,8 +75,12 @@ void setNegativeGif(bool val);
 bool getTimeFormat24h();
 void setTimeFormat24h(bool val);
 
-// --- Game high score ---
+// --- Game high score (T-Rex Runner) ---
 uint32_t getGameHighScore();
 void     setGameHighScore(uint32_t score);
+
+// --- Flappy Bird high score ---
+uint32_t getFlappyHighScore();
+void     setFlappyHighScore(uint32_t score);
 
 #endif // SETTINGS_H


### PR DESCRIPTION
feat: add Flappy Bird game

- Add flappy_bird.h / flappy_bird.cpp: full game implementation
  - 8×6 pixel bird sprite with 3-frame wing animation (mid/up/down)
  - Sub-pixel (×4) physics: flap impulse, gravity, terminal velocity
  - 2 recycled pipe pairs with body + cap rendering and 18 px gap
  - Inner-padded AABB collision for fair play
  - Speed increases every 8 pipes scored (2→5 px/tick)
  - HUD mirrors T-Rex Runner style (HI / current score)
  - Game-over screen with score, best, retry/exit hints

- settings: add getFlappyHighScore() / setFlappyHighScore() persisted
  to NVS key "flappyHi", independent of T-Rex high score

- app_state: add FLAPPY_RUNNING and FLAPPY_OVER display states

- game_menu: add "Flappy Bird" as second menu entry; add Launch1 action

- display_task: wire Flappy Bird into state machine
  - Launch1 → flappyEnter() + FLAPPY_RUNNING
  - Gesture handler: tap/touch-up triggers flap with buzzer feedback
  - Tick loop: draw → tick → game-over transition with high-score save
  - Suppress MQTT touch-event publish during FLAPPY_RUNNING/OVER