### PR TITLE
feat: add Car Avoidance game with state management and scoring

### DIFF
--- a/firmware/src/app_state.h
+++ b/firmware/src/app_state.h
@@ -35,7 +35,9 @@ enum DisplayState {
     TREX_RUNNING,
     TREX_OVER,
     FLAPPY_RUNNING,
-    FLAPPY_OVER
+    FLAPPY_OVER,
+    CAR_RUNNING,
+    CAR_OVER
 };
 
 // ==========================================================================

--- a/firmware/src/display_task.cpp
+++ b/firmware/src/display_task.cpp
@@ -16,6 +16,7 @@
 #include "games/game_menu.h"
 #include "games/trex_runner/trex_runner.h"
 #include "games/flappy_bird/flappy_bird.h"
+#include "games/car_avoidance/car_avoidance.h"
 
 #include "gif_types.h"
 #include "sys_scx.h"
@@ -97,7 +98,8 @@ static SettingsPending _settingsPending;
 // Helper: whether current display state is any in-game view
 static bool isGameDisplayState(DisplayState s) {
     return s == TREX_RUNNING || s == TREX_OVER ||
-           s == FLAPPY_RUNNING || s == FLAPPY_OVER;
+           s == FLAPPY_RUNNING || s == FLAPPY_OVER ||
+           s == CAR_RUNNING || s == CAR_OVER;
 }
 
 // ==========================================================================
@@ -790,6 +792,15 @@ void displayTask(void *param) {
                             flappyEnter();
                             enterState(FLAPPY_RUNNING);
                             flappyDrawFrame();
+                        } else if (ma == GameMenuAction::Launch2) {
+                            updateAvailable = false;
+                            carAvoidanceEnter();
+                            if (getBuzzerVolume() > 0) {
+                                noTone(getPinBuzzer());
+                                rtttl::begin(getPinBuzzer(), CAR_START_MELODY);
+                            }
+                            enterState(CAR_RUNNING);
+                            carAvoidanceDrawFrame();
                         } else if (ma == GameMenuAction::OpenContribute) {
                             enterState(GAME_CONTRIBUTE);
                             drawContributeScreen();
@@ -907,6 +918,41 @@ void displayTask(void *param) {
                         flappyEnter();
                         enterState(FLAPPY_RUNNING);
                         flappyDrawFrame();
+                    } else if (gesture.type == LONG_PRESS) {
+                        enterState(GIF_PLAYBACK);
+                    }
+                    break;
+
+                case CAR_RUNNING: {
+                    CarGestureType cg = CarGestureType::None;
+                    if (gesture.type == TOUCH_UP)         cg = CarGestureType::TouchUp;
+                    else if (gesture.type == TOUCH_DOWN)  cg = CarGestureType::TouchDown;
+                    else if (gesture.type == SINGLE_TAP)  cg = CarGestureType::SingleTap;
+                    else if (gesture.type == DOUBLE_TAP)  cg = CarGestureType::DoubleTap;
+                    else if (gesture.type == LONG_PRESS)  cg = CarGestureType::LongPress;
+                    CarAction cra = carAvoidanceOnGesture(cg);
+                    if (cra == CarAction::ChangeLane) {
+                        carAvoidanceApplyChangeLane();
+                        if (getBuzzerVolume() > 0) {
+                            noTone(getPinBuzzer());
+                            rtttl::begin(getPinBuzzer(), TOUCH_MELODY);
+                        }
+                    } else if (cra == CarAction::Exit) {
+                        enterState(GIF_PLAYBACK);
+                    }
+                    break;
+                }
+
+                case CAR_OVER:
+                    if (now - _stateEntryMs < 1500) break;
+                    if (gesture.type == SINGLE_TAP) {
+                        carAvoidanceEnter();
+                        if (getBuzzerVolume() > 0) {
+                            noTone(getPinBuzzer());
+                            rtttl::begin(getPinBuzzer(), CAR_START_MELODY);
+                        }
+                        enterState(CAR_RUNNING);
+                        carAvoidanceDrawFrame();
                     } else if (gesture.type == LONG_PRESS) {
                         enterState(GIF_PLAYBACK);
                     }
@@ -1188,6 +1234,26 @@ void displayTask(void *param) {
                 break;
 
             case FLAPPY_OVER:
+                // Idle — waiting for gesture
+                break;
+
+            case CAR_RUNNING:
+                carAvoidanceDrawFrame(now);
+                if (carAvoidanceTick(now)) {
+                    setCarHighScore(carAvoidanceGetScore());
+                    if (getBuzzerVolume() > 0) {
+                        noTone(getPinBuzzer());
+                        rtttl::begin(getPinBuzzer(), CAR_CRASH_MELODY);
+                    }
+                    enterState(CAR_OVER);
+                    carAvoidanceDrawGameOver();
+                } else if (carAvoidanceNearMiss() && getBuzzerVolume() > 0) {
+                    noTone(getPinBuzzer());
+                    rtttl::begin(getPinBuzzer(), CAR_NEAR_MELODY);
+                }
+                break;
+
+            case CAR_OVER:
                 // Idle — waiting for gesture
                 break;
 

--- a/firmware/src/games/car_avoidance/car_avoidance.cpp
+++ b/firmware/src/games/car_avoidance/car_avoidance.cpp
@@ -1,0 +1,388 @@
+// ==========================================================================
+//  QBIT -- Car Avoidance game implementation
+//  Display: 128x64 OLED.
+//  Tap/TouchUp = change to next lane (0→1→2→0).
+//  Avoid enemy cars scrolling from the top; survive as long as possible.
+// ==========================================================================
+#include "car_avoidance.h"
+#include "app_state.h"
+#include "display_helpers.h"
+#include "settings.h"
+#include <stdio.h>
+
+// --------------------------------------------------------------------------
+//  Constants
+// --------------------------------------------------------------------------
+
+// Road geometry
+#define CA_ROAD_X           22      // X of left road wall pixel
+#define CA_ROAD_W           84      // total road width including both wall pixels (3×28)
+#define CA_LANE_W           28      // width of each lane in pixels
+#define CA_NUM_LANES        3
+
+// Road vertical extents
+#define CA_ROAD_TOP_Y       10      // Y of top border line
+#define CA_ROAD_BTM_Y       57      // Y of bottom border line
+
+// Car sprite dimensions
+#define CA_CAR_W            8       // sprite width for both player and enemy
+#define CA_CAR_H            12      // player car sprite height
+#define CA_ENEMY_H          10      // enemy car sprite height
+
+// Player car: fixed near the bottom of the road area
+// bottom = CA_PLAYER_TOP_Y + CA_CAR_H - 1 = 55  (inside road at y<57)
+#define CA_PLAYER_TOP_Y     44
+
+// Enemy car lifecycle
+#define CA_SPAWN_Y          (CA_ROAD_TOP_Y + 1)   // just inside top border
+#define CA_DESPAWN_Y        CA_ROAD_BTM_Y          // removed when y reaches bottom border
+
+#define CA_MAX_ENEMIES      4
+
+// Timing
+#define CA_TICK_MS          35      // ms per tick (~28 fps)
+
+// Difficulty scaling
+#define CA_SPEED_INIT       2       // starting scroll speed (px/tick)
+#define CA_SPEED_MAX        6       // maximum scroll speed
+#define CA_SPEEDUP_SCORE    80      // gain one speed level per 80 score points
+
+// Spawn interval limits (in ticks)
+#define CA_SPAWN_MIN_TICKS  8
+#define CA_SPAWN_MAX_TICKS  22
+
+// Near-miss: adjacent-lane enemy within this many pixels vertically of player box
+#define CA_NEAR_MISS_PX     5
+
+// Road lane-divider dash animation
+#define CA_DASH_PERIOD      12      // pixels per dash cycle (on + off)
+#define CA_DASH_ON          6       // pixels lit per cycle
+
+// --------------------------------------------------------------------------
+//  Lane car-left-edge look-up table
+//  Lane n center = CA_ROAD_X + n*CA_LANE_W + CA_LANE_W/2
+//  Car left    = center - CA_CAR_W/2
+//  Lane 0: center=36 → left=32 | Lane 1: center=64 → left=60 | Lane 2: center=92 → left=88
+// --------------------------------------------------------------------------
+static const int8_t CA_LANE_X[CA_NUM_LANES] = { 32, 60, 88 };
+
+// Lane divider X positions (interior, between pairs of adjacent lanes)
+static const uint8_t CA_DIV_X[CA_NUM_LANES - 1] = { 50, 78 };
+
+// --------------------------------------------------------------------------
+//  Sprites
+//  Each byte = one row; bit 7 = leftmost pixel (col 0), bit 0 = rightmost (col 7).
+//  Stored in flash with PROGMEM; read with pgm_read_byte().
+// --------------------------------------------------------------------------
+
+// Player car (8W × 12H): top-down view, front of car faces UP (toward enemies).
+//  Row  0: .XXXXXX.  0x7E  front bumper / headlights
+//  Row  1: XXXXXXXX  0xFF  hood
+//  Row  2: X.XXXX.X  0xBD  windshield frame
+//  Row  3: X.XXXX.X  0xBD  windshield frame
+//  Row  4: XXXXXXXX  0xFF  dashboard
+//  Row  5: XX.XX.XX  0xDB  driver + passenger
+//  Row  6: XXXXXXXX  0xFF  rear seat area
+//  Row  7: X.XXXX.X  0xBD  rear windshield frame
+//  Row  8: X.XXXX.X  0xBD  rear windshield frame
+//  Row  9: XXXXXXXX  0xFF  trunk
+//  Row 10: X..XX..X  0x99  rear wheel arches
+//  Row 11: .XXXXXX.  0x7E  tail lights / rear bumper
+static const uint8_t PLAYER_CAR[CA_CAR_H] PROGMEM = {
+    0x7E, 0xFF, 0xBD, 0xBD,
+    0xFF, 0xDB, 0xFF, 0xBD,
+    0xBD, 0xFF, 0x99, 0x7E
+};
+
+// Enemy car (8W × 10H): traveling downward.
+// Front of car faces DOWN (bottom of sprite), rear faces UP (top of sprite).
+//  Row  0: .XXXXXX.  0x7E  tail lights / rear bumper  (top = furthest from player)
+//  Row  1: X..XX..X  0x99  rear wheel arches
+//  Row  2: XXXXXXXX  0xFF  trunk
+//  Row  3: X.XXXX.X  0xBD  rear windshield frame
+//  Row  4: X.XXXX.X  0xBD  rear windshield frame
+//  Row  5: XXXXXXXX  0xFF  body
+//  Row  6: XX.XX.XX  0xDB  seats
+//  Row  7: XXXXXXXX  0xFF  hood
+//  Row  8: X..XX..X  0x99  front wheel arches
+//  Row  9: .XXXXXX.  0x7E  front bumper / headlights  (bottom = closest to player)
+static const uint8_t ENEMY_CAR[CA_ENEMY_H] PROGMEM = {
+    0x7E, 0x99, 0xFF, 0xBD,
+    0xBD, 0xFF, 0xDB, 0xFF,
+    0x99, 0x7E
+};
+
+// --------------------------------------------------------------------------
+//  Types
+// --------------------------------------------------------------------------
+struct EnemyCar {
+    int16_t y;
+    uint8_t lane;
+    bool    active;
+    bool    nearMissed;  // true once near-miss sound has been triggered for this car
+};
+
+// --------------------------------------------------------------------------
+//  State
+// --------------------------------------------------------------------------
+static uint8_t       _playerLane    = 1;
+static bool          _dead          = false;
+static uint32_t      _score         = 0;
+static uint8_t       _speed         = CA_SPEED_INIT;
+static unsigned long _lastTickMs    = 0;
+static EnemyCar      _enemies[CA_MAX_ENEMIES];
+static uint16_t      _randState     = 1;
+static int16_t       _dashOffset    = 0;
+static uint8_t       _spawnTimer    = 0;       // ticks until next spawn attempt
+static uint8_t       _spawnInterval = CA_SPAWN_MAX_TICKS;
+static bool          _nearMiss      = false;
+
+// --------------------------------------------------------------------------
+//  XOR-shift RNG (same pattern as flappy_bird.cpp)
+// --------------------------------------------------------------------------
+static uint16_t caRand() {
+    if (_randState == 0) _randState = 1;
+    _randState ^= _randState << 7;
+    _randState ^= _randState >> 9;
+    _randState ^= _randState << 8;
+    return _randState;
+}
+
+// --------------------------------------------------------------------------
+//  Draw one car sprite, clipped to road interior
+// --------------------------------------------------------------------------
+static void drawCar(int8_t left, int16_t top, const uint8_t *sprite, uint8_t h) {
+    u8g2.setDrawColor(1);
+    for (uint8_t row = 0; row < h; row++) {
+        int16_t sy = top + (int16_t)row;
+        if (sy <= CA_ROAD_TOP_Y || sy >= CA_ROAD_BTM_Y) continue;
+        uint8_t bits = pgm_read_byte(&sprite[row]);
+        for (uint8_t col = 0; col < CA_CAR_W; col++) {
+            if (bits & (0x80u >> col)) {
+                int16_t sx = (int16_t)left + (int16_t)col;
+                if (sx > CA_ROAD_X && sx < CA_ROAD_X + (int16_t)CA_ROAD_W - 1)
+                    u8g2.drawPixel((uint8_t)sx, (uint8_t)sy);
+            }
+        }
+    }
+}
+
+// --------------------------------------------------------------------------
+//  Draw scrolling road (borders + dashed lane dividers)
+// --------------------------------------------------------------------------
+static void drawRoad() {
+    u8g2.setDrawColor(1);
+
+    // Horizontal border lines
+    u8g2.drawHLine(CA_ROAD_X, CA_ROAD_TOP_Y, CA_ROAD_W);
+    u8g2.drawHLine(CA_ROAD_X, CA_ROAD_BTM_Y, CA_ROAD_W);
+
+    // Vertical road walls
+    u8g2.drawVLine(CA_ROAD_X,
+                   CA_ROAD_TOP_Y, CA_ROAD_BTM_Y - CA_ROAD_TOP_Y + 1);
+    u8g2.drawVLine(CA_ROAD_X + CA_ROAD_W - 1,
+                   CA_ROAD_TOP_Y, CA_ROAD_BTM_Y - CA_ROAD_TOP_Y + 1);
+
+    // Dashed lane dividers — dash offset scrolls to simulate forward motion
+    for (uint8_t d = 0; d < (uint8_t)(CA_NUM_LANES - 1); d++) {
+        uint8_t dx = CA_DIV_X[d];
+        for (int16_t y = CA_ROAD_TOP_Y + 1; y < CA_ROAD_BTM_Y; y++) {
+            uint8_t phase = (uint8_t)((uint16_t)(y + _dashOffset) % CA_DASH_PERIOD);
+            if (phase < CA_DASH_ON)
+                u8g2.drawPixel(dx, (uint8_t)y);
+        }
+    }
+}
+
+// --------------------------------------------------------------------------
+//  Spawn one enemy car if a slot is free and lane spacing allows
+// --------------------------------------------------------------------------
+static void spawnEnemy() {
+    // Find a free slot
+    int8_t slot = -1;
+    for (uint8_t i = 0; i < CA_MAX_ENEMIES; i++) {
+        if (!_enemies[i].active) { slot = i; break; }
+    }
+    if (slot < 0) return;
+
+    // Pick a random lane; retry up to 3 times to avoid crowding the spawn row
+    uint8_t lane = 0;
+    for (uint8_t attempt = 0; attempt < 3; attempt++) {
+        lane = (uint8_t)(caRand() % CA_NUM_LANES);
+        bool blocked = false;
+        for (uint8_t i = 0; i < CA_MAX_ENEMIES; i++) {
+            if (_enemies[i].active && _enemies[i].lane == lane &&
+                _enemies[i].y < CA_ROAD_TOP_Y + CA_ENEMY_H + 4) {
+                blocked = true;
+                break;
+            }
+        }
+        if (!blocked) break;
+    }
+
+    _enemies[slot] = { (int16_t)CA_SPAWN_Y, lane, true, false };
+}
+
+// --------------------------------------------------------------------------
+//  Public API
+// --------------------------------------------------------------------------
+
+void carAvoidanceEnter() {
+    _randState     = (uint16_t)(millis() & 0xFFFF) | 1;
+    _playerLane    = 1;
+    _dead          = false;
+    _score         = 0;
+    _speed         = CA_SPEED_INIT;
+    _lastTickMs    = millis();
+    _dashOffset    = 0;
+    _spawnTimer    = 10;                    // short delay before first enemy
+    _spawnInterval = CA_SPAWN_MAX_TICKS;
+    _nearMiss      = false;
+    for (uint8_t i = 0; i < CA_MAX_ENEMIES; i++)
+        _enemies[i].active = false;
+}
+
+void carAvoidanceDrawFrame(unsigned long /*nowMs*/) {
+    u8g2.clearBuffer();
+    u8g2.setDrawColor(1);
+
+    // HUD: high score and current score (right-aligned, matching Flappy Bird style)
+    char hud[24];
+    snprintf(hud, sizeof(hud), "HI %04lu  %04lu",
+             (unsigned long)getCarHighScore(), (unsigned long)_score);
+    u8g2.setFont(u8g2_font_6x10_tr);
+    uint8_t hudW = u8g2.getStrWidth(hud);
+    u8g2.drawStr((int16_t)(128 - (int16_t)hudW - 2), 9, hud);
+
+    // Road
+    drawRoad();
+
+    // Enemy cars
+    for (uint8_t i = 0; i < CA_MAX_ENEMIES; i++) {
+        if (_enemies[i].active)
+            drawCar(CA_LANE_X[_enemies[i].lane], _enemies[i].y,
+                    ENEMY_CAR, CA_ENEMY_H);
+    }
+
+    // Player car
+    drawCar(CA_LANE_X[_playerLane], CA_PLAYER_TOP_Y, PLAYER_CAR, CA_CAR_H);
+
+    rotateBuffer180();
+    u8g2.sendBuffer();
+}
+
+void carAvoidanceDrawGameOver() {
+    u8g2.clearBuffer();
+    u8g2.setFont(u8g2_font_6x13_tr);
+
+    const char *hdr = "[ Car Avoidance ]";
+    u8g2.drawStr((128 - (int16_t)u8g2.getStrWidth(hdr)) / 2, 13, hdr);
+
+    char scoreLine[20], bestLine[20];
+    snprintf(scoreLine, sizeof(scoreLine), "Score: %04lu", (unsigned long)_score);
+    snprintf(bestLine,  sizeof(bestLine),  "Best:  %04lu", (unsigned long)getCarHighScore());
+    u8g2.drawStr((128 - (int16_t)u8g2.getStrWidth(scoreLine)) / 2, 32, scoreLine);
+    u8g2.drawStr((128 - (int16_t)u8g2.getStrWidth(bestLine))  / 2, 46, bestLine);
+
+    const char *hint = "TAP=retry  HOLD=exit";
+    u8g2.drawStr((128 - (int16_t)u8g2.getStrWidth(hint)) / 2, 62, hint);
+
+    rotateBuffer180();
+    u8g2.sendBuffer();
+}
+
+CarAction carAvoidanceOnGesture(CarGestureType g) {
+    if (g == CarGestureType::TouchUp || g == CarGestureType::SingleTap)
+        return CarAction::ChangeLane;
+    if (g == CarGestureType::LongPress)
+        return CarAction::Exit;
+    return CarAction::None;
+}
+
+void carAvoidanceApplyChangeLane() {
+    if (_dead) return;
+    _playerLane = (_playerLane + 1) % CA_NUM_LANES;
+}
+
+bool carAvoidanceTick(unsigned long nowMs) {
+    if (nowMs - _lastTickMs < CA_TICK_MS) return false;
+    _lastTickMs = nowMs;
+
+    if (_dead) return false;
+
+    _score++;
+
+    // Speed: one level per CA_SPEEDUP_SCORE points, capped at CA_SPEED_MAX
+    uint8_t newSpeed = (uint8_t)(CA_SPEED_INIT + _score / CA_SPEEDUP_SCORE);
+    if (newSpeed > CA_SPEED_MAX) newSpeed = CA_SPEED_MAX;
+    _speed = newSpeed;
+
+    // Tighten spawn interval as speed grows
+    int8_t spawnAdj = (int8_t)(CA_SPAWN_MAX_TICKS - (_speed - CA_SPEED_INIT) * 3);
+    _spawnInterval = (spawnAdj < (int8_t)CA_SPAWN_MIN_TICKS)
+                     ? CA_SPAWN_MIN_TICKS : (uint8_t)spawnAdj;
+
+    // Scroll road dash pattern
+    _dashOffset = (int16_t)(((int32_t)_dashOffset + _speed) % CA_DASH_PERIOD);
+
+    // Spawn timer
+    if (_spawnTimer > 0) {
+        _spawnTimer--;
+    } else {
+        spawnEnemy();
+        _spawnTimer = _spawnInterval + (uint8_t)(caRand() % (_spawnInterval / 2 + 1));
+    }
+
+    // Player hitbox
+    int16_t pLeft = (int16_t)CA_LANE_X[_playerLane];
+    int16_t pTop  = (int16_t)CA_PLAYER_TOP_Y;
+    int16_t pBtm  = pTop + (int16_t)CA_CAR_H - 1;
+
+    _nearMiss = false;
+    bool crashed = false;
+
+    for (uint8_t i = 0; i < CA_MAX_ENEMIES && !crashed; i++) {
+        if (!_enemies[i].active) continue;
+
+        _enemies[i].y += (int16_t)_speed;
+
+        // Despawn once past bottom border
+        if (_enemies[i].y >= (int16_t)CA_DESPAWN_Y) {
+            _enemies[i].active = false;
+            continue;
+        }
+
+        int16_t eTop = _enemies[i].y;
+        int16_t eBtm = eTop + (int16_t)CA_ENEMY_H - 1;
+
+        // Collision — same lane; X overlap guaranteed for same lane, check Y only
+        if (_enemies[i].lane == _playerLane) {
+            if (eTop <= pBtm && eBtm >= pTop) {
+                crashed = true;
+                _dead   = true;
+            }
+        }
+
+        // Near-miss — adjacent lane, vertically close to player
+        if (!_enemies[i].nearMissed && !crashed) {
+            int8_t laneDiff = (int8_t)_enemies[i].lane - (int8_t)_playerLane;
+            if (laneDiff == 1 || laneDiff == -1) {
+                if (eBtm >= pTop - (int16_t)CA_NEAR_MISS_PX &&
+                    eTop <= pBtm + (int16_t)CA_NEAR_MISS_PX) {
+                    _enemies[i].nearMissed = true;
+                    _nearMiss = true;
+                }
+            }
+        }
+    }
+
+    return crashed;
+}
+
+bool carAvoidanceNearMiss() {
+    return _nearMiss;
+}
+
+uint32_t carAvoidanceGetScore() {
+    return _score;
+}

--- a/firmware/src/games/car_avoidance/car_avoidance.h
+++ b/firmware/src/games/car_avoidance/car_avoidance.h
@@ -1,0 +1,41 @@
+// ==========================================================================
+//  QBIT -- Car Avoidance (128x64, tap to change lanes, avoid enemy cars)
+// ==========================================================================
+#ifndef CAR_AVOIDANCE_H
+#define CAR_AVOIDANCE_H
+
+#include <Arduino.h>
+
+enum class CarGestureType {
+    None, TouchDown, TouchUp, SingleTap, DoubleTap, LongPress
+};
+
+enum class CarAction {
+    None, ChangeLane, Exit
+};
+
+// Reset state. Call before entering CAR_RUNNING.
+void carAvoidanceEnter();
+
+// Draw current frame (HUD, road, cars). nowMs is kept for API consistency.
+void carAvoidanceDrawFrame(unsigned long nowMs = 0);
+
+// Draw game over screen (score + best). Call after entering CAR_OVER.
+void carAvoidanceDrawGameOver();
+
+// Run one game tick (scroll, spawn, collision). Returns true if game over (crash).
+bool carAvoidanceTick(unsigned long nowMs);
+
+// Returns true if a near-miss was detected on the most recent tick.
+bool carAvoidanceNearMiss();
+
+// Current score (read after carAvoidanceTick() returns true before saving high score).
+uint32_t carAvoidanceGetScore();
+
+// Handle gesture during play. Returns ChangeLane or Exit.
+CarAction carAvoidanceOnGesture(CarGestureType g);
+
+// Apply lane change (cycle right: lane 0→1→2→0).
+void carAvoidanceApplyChangeLane();
+
+#endif // CAR_AVOIDANCE_H

--- a/firmware/src/games/game_menu.cpp
+++ b/firmware/src/games/game_menu.cpp
@@ -9,9 +9,10 @@
 static const char *GAME_MENU_LABELS[] = {
     "T-Rex Runner",
     "Flappy Bird",
+    "Car Avoidance",
     "More games",
 };
-static const uint8_t GAME_MENU_COUNT_VAL = 3;
+static const uint8_t GAME_MENU_COUNT_VAL = 4;
 
 static uint8_t _cursor = 0;
 
@@ -77,7 +78,8 @@ GameMenuAction gameMenuOnGesture(GameMenuGestureType g) {
     if (g == GameMenuGestureType::LongPress) {
         if (_cursor == 0) return GameMenuAction::Launch0;
         if (_cursor == 1) return GameMenuAction::Launch1;
-        if (_cursor == 2) return GameMenuAction::OpenContribute;
+        if (_cursor == 2) return GameMenuAction::Launch2;
+        if (_cursor == 3) return GameMenuAction::OpenContribute;
         return GameMenuAction::None;
     }
     if (g == GameMenuGestureType::DoubleTap)

--- a/firmware/src/games/game_menu.h
+++ b/firmware/src/games/game_menu.h
@@ -15,6 +15,7 @@ enum class GameMenuAction {
     Scroll,         // cursor moved (caller redraws)
     Launch0,        // launch game index 0 (T-Rex Runner)
     Launch1,        // launch game index 1 (Flappy Bird)
+    Launch2,        // launch game index 2 (Car Avoidance)
     OpenContribute, // open "contribute" hint (fake "More games" item)
     Back            // return to settings
 };

--- a/firmware/src/melodies.h
+++ b/firmware/src/melodies.h
@@ -33,4 +33,16 @@ static const char UNMUTE_MELODY[] =
 static const char TIMER_MELODY[] =
     "timer:d=8,o=5,b=200:c6,c6,e6,c6,e6,g6";
 
+// Car Avoidance: game start jingle (short ascending arpeggio)
+static const char CAR_START_MELODY[] =
+    "carstart:d=16,o=5,b=240:c,e,g,c6";
+
+// Car Avoidance: near-miss warning (two sharp beeps)
+static const char CAR_NEAR_MELODY[] =
+    "nearmiss:d=32,o=6,b=400:c,4p,c";
+
+// Car Avoidance: crash sound (descending tones)
+static const char CAR_CRASH_MELODY[] =
+    "carcrash:d=8,o=5,b=120:a,f,c";
+
 #endif // MELODIES_H

--- a/firmware/src/settings.cpp
+++ b/firmware/src/settings.cpp
@@ -50,8 +50,9 @@ static String  _tzIANA;
 static bool _flipMode        = true;
 
 // T-Rex Runner high score (stored under key "trexHi")
-static uint32_t _trexHighScore  = 0;
+static uint32_t _trexHighScore   = 0;
 static uint32_t _flappyHighScore = 0;
+static uint32_t _carHighScore    = 0;
 static bool _negativeGif     = false;
 
 // Time format: true = 24h, false = 12h
@@ -155,6 +156,7 @@ void loadSettings() {
     _timeFormat24h   = _prefs.getBool("time24h",   true);
     _trexHighScore   = _prefs.getUInt("trexHi",    0);
     _flappyHighScore = _prefs.getUInt("flappyHi",  0);
+    _carHighScore    = _prefs.getUInt("carHi",      0);
     xSemaphoreGive(_prefsMutex);
 
     // Apply speed
@@ -194,6 +196,7 @@ void saveSettings() {
     _prefs.putBool("time24h",    _timeFormat24h);
     _prefs.putUInt("trexHi",     _trexHighScore);
     _prefs.putUInt("flappyHi",   _flappyHighScore);
+    _prefs.putUInt("carHi",      _carHighScore);
     xSemaphoreGive(_prefsMutex);
     Serial.println("Settings saved to NVS");
 }
@@ -321,6 +324,18 @@ void     setFlappyHighScore(uint32_t s) {
         // Persist immediately so it survives power-off
         if (_prefsReady && xSemaphoreTake(_prefsMutex, portMAX_DELAY) == pdTRUE) {
             _prefs.putUInt("flappyHi", _flappyHighScore);
+            xSemaphoreGive(_prefsMutex);
+        }
+    }
+}
+
+// Car Avoidance
+uint32_t getCarHighScore()           { return _carHighScore; }
+void     setCarHighScore(uint32_t s) {
+    if (s > _carHighScore) {
+        _carHighScore = s;
+        if (_prefsReady && xSemaphoreTake(_prefsMutex, portMAX_DELAY) == pdTRUE) {
+            _prefs.putUInt("carHi", _carHighScore);
             xSemaphoreGive(_prefsMutex);
         }
     }

--- a/firmware/src/settings.h
+++ b/firmware/src/settings.h
@@ -83,4 +83,8 @@ void     setTrexHighScore(uint32_t score);
 uint32_t getFlappyHighScore();
 void     setFlappyHighScore(uint32_t score);
 
+// --- Car Avoidance high score ---
+uint32_t getCarHighScore();
+void     setCarHighScore(uint32_t score);
+
 #endif // SETTINGS_H


### PR DESCRIPTION
feat: Add Car Avoidance game

Adds a new single-touch arcade game, Car Avoidance, to the QBIT game library following the same architecture as T-Rex Runner and Flappy Bird.

Gameplay:
Your car sits near the bottom of a 3-lane road. Enemy cars scroll down from the top at increasing speed. Tap to cycle your car to the next lane (0 to 1 to 2 and back to 0). Survive as long as possible — score increments every tick and the scroll speed increases over time. High score is saved to NVS and persists across power cycles.

Controls:

Tap or touch-up: change lane
Long press in-game: exit to home screen
Tap on game over screen: retry
Long press on game over screen: exit to home screen
Buzzer feedback:

Game start: short ascending arpeggio
Lane change: coin beep (shared with other games)
Near miss: double sharp beep
Crash: descending tone sequence
Files changed:

[car_avoidance.h](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and car_avoidance.cpp — new game module with 3-lane road renderer, scrolling dashed lane dividers, PROGMEM car sprites (player 8x12, enemy 8x10), XOR-shift RNG for enemy spawning, near-miss detection, and NVS high score persistence.

[app_state.h](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — added CAR_RUNNING and CAR_OVER display states.

[settings.h](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [settings.cpp](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — added getCarHighScore and setCarHighScore with immediate NVS write-through under key carHi.

[melodies.h](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — added CAR_START_MELODY, CAR_NEAR_MELODY, and CAR_CRASH_MELODY.

[game_menu.h](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [game_menu.cpp](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — added Car Avoidance as menu entry index 2 with a Launch2 action; menu now has 4 items.

[display_task.cpp](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — wired Launch2 handler, gesture cases for CAR_RUNNING and CAR_OVER, tick and draw loop, and near-miss sound trigger.feat: Add Car Avoidance game

Adds a new single-touch arcade game, Car Avoidance, to the QBIT game library following the same architecture as T-Rex Runner and Flappy Bird.

Gameplay:
Your car sits near the bottom of a 3-lane road. Enemy cars scroll down from the top at increasing speed. Tap to cycle your car to the next lane (0 to 1 to 2 and back to 0). Survive as long as possible — score increments every tick and the scroll speed increases over time. High score is saved to NVS and persists across power cycles.

Controls:

Tap or touch-up: change lane
Long press in-game: exit to home screen
Tap on game over screen: retry
Long press on game over screen: exit to home screen
Buzzer feedback:

Game start: short ascending arpeggio
Lane change: coin beep (shared with other games)
Near miss: double sharp beep
Crash: descending tone sequence
Files changed:

[car_avoidance.h](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and car_avoidance.cpp — new game module with 3-lane road renderer, scrolling dashed lane dividers, PROGMEM car sprites (player 8x12, enemy 8x10), XOR-shift RNG for enemy spawning, near-miss detection, and NVS high score persistence.

[app_state.h](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — added CAR_RUNNING and CAR_OVER display states.

[settings.h](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [settings.cpp](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — added getCarHighScore and setCarHighScore with immediate NVS write-through under key carHi.

[melodies.h](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — added CAR_START_MELODY, CAR_NEAR_MELODY, and CAR_CRASH_MELODY.

[game_menu.h](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [game_menu.cpp](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — added Car Avoidance as menu entry index 2 with a Launch2 action; menu now has 4 items.

[display_task.cpp](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) — wired Launch2 handler, gesture cases for CAR_RUNNING and CAR_OVER, tick and draw loop, and near-miss sound trigger.