### PR TITLE
feat: implement live drawing feature with OLED integration and UI control

### DIFF
--- a/firmware/data/index.html
+++ b/firmware/data/index.html
@@ -202,7 +202,7 @@
       <button class="btn btn-save" id="btnDrawSend" type="button">Send</button>
     </div>
     <div class="draw-canvas-wrap">
-      <canvas id="drawCanvas" width="512" height="256"></canvas>
+      <canvas id="drawCanvas" width="128" height="64"></canvas>
     </div>
     <div class="msg" id="drawMsg"></div>
   </div>

--- a/firmware/data/index.html
+++ b/firmware/data/index.html
@@ -121,6 +121,14 @@
       <label class="setting-label">Sound</label>
       <button class="btn btn-mute" id="btnMute">ON</button>
     </div>
+    <div class="setting">
+      <label class="setting-label">Flip</label>
+      <button class="btn btn-mute" id="btnFlip">OFF</button>
+    </div>
+    <div class="setting">
+      <label class="setting-label">GIF Invert</label>
+      <button class="btn btn-mute" id="btnNegative">OFF</button>
+    </div>
     <button class="btn btn-save" id="btnSave">Save</button>
   </div>
 
@@ -183,6 +191,21 @@
     <button class="btn btn-save" id="btnPinSave">Save Pins</button>
   </div>
 
+
+  <div class="card collapsible collapsed" id="drawCard">
+    <div class="card-title">Draw on OLED</div>
+    <div class="draw-tools">
+      <button class="btn btn-tool" id="btnPen" type="button">Pen</button>
+      <button class="btn btn-tool" id="btnEraser" type="button">Eraser</button>
+      <button class="btn btn-secondary" id="btnDrawClear" type="button">Clear</button>
+      <button class="btn btn-tool" id="btnLive" type="button">Live</button>
+      <button class="btn btn-save" id="btnDrawSend" type="button">Send</button>
+    </div>
+    <div class="draw-canvas-wrap">
+      <canvas id="drawCanvas" width="512" height="256"></canvas>
+    </div>
+    <div class="msg" id="drawMsg"></div>
+  </div>
 
   <script src="/jszip.min.js"></script>
   <script src="/script.js"></script>

--- a/firmware/data/script.js
+++ b/firmware/data/script.js
@@ -201,24 +201,40 @@ function fmt(b) {
 
 // Settings controls -- fetch current values and send changes on input
 (function () {
-  var rSpeed  = document.getElementById('rSpeed');
-  var rBright = document.getElementById('rBright');
-  var btnMute = document.getElementById('btnMute');
-  var vSpeed  = document.getElementById('vSpeed');
-  var vBright = document.getElementById('vBright');
-  var _muted  = false;
+  var rSpeed    = document.getElementById('rSpeed');
+  var rBright   = document.getElementById('rBright');
+  var btnMute   = document.getElementById('btnMute');
+  var btnFlip   = document.getElementById('btnFlip');
+  var btnNeg    = document.getElementById('btnNegative');
+  var vSpeed    = document.getElementById('vSpeed');
+  var vBright   = document.getElementById('vBright');
+  var _muted    = false;
+  var _flip     = false;
+  var _negative = false;
 
   function updateMuteBtn() {
     btnMute.textContent = _muted ? 'OFF' : 'ON';
     btnMute.classList.toggle('muted', _muted);
+  }
+  function updateFlipBtn() {
+    btnFlip.textContent = _flip ? 'ON' : 'OFF';
+    btnFlip.classList.toggle('muted', !_flip);
+  }
+  function updateNegBtn() {
+    btnNeg.textContent = _negative ? 'ON' : 'OFF';
+    btnNeg.classList.toggle('muted', !_negative);
   }
 
   // Fetch current settings from device
   fetch('/api/settings').then(function (r) { return r.json(); }).then(function (s) {
     rSpeed.value  = s.speed;       vSpeed.textContent  = s.speed;
     rBright.value = s.brightness;  vBright.textContent = s.brightness;
-    _muted = s.volume === 0;
+    _muted    = s.volume === 0;
+    _flip     = !!s.flip;
+    _negative = !!s.negative;
     updateMuteBtn();
+    updateFlipBtn();
+    updateNegBtn();
   }).catch(function () {});
 
   // Debounce helper -- sends POST after user stops dragging for 150ms
@@ -242,6 +258,16 @@ function fmt(b) {
     _muted = !_muted;
     updateMuteBtn();
     send('volume', _muted ? 0 : 100);
+  });
+  btnFlip.addEventListener('click', function () {
+    _flip = !_flip;
+    updateFlipBtn();
+    send('flip', _flip ? 1 : 0);
+  });
+  btnNeg.addEventListener('click', function () {
+    _negative = !_negative;
+    updateNegBtn();
+    send('negative', _negative ? 1 : 0);
   });
 
   // Save button -- persist current settings to NVS
@@ -667,3 +693,170 @@ setInterval(pollCurrent, 3000);
 ls();
 lf();
 pollCurrent();
+
+// Live drawing to OLED (Draw card)
+(function () {
+  var SCALE = 4;
+  var W = 128, H = 64;
+  // U8G2 page-addressed buffer: buf[page*128 + col], bit=(row%8); bit=1 → white pixel
+  var buf = new Uint8Array(1024);
+  var tool = 'pen';
+  var isDown = false;
+  var _liveMode = false;
+  var _liveTimer = null;
+
+  var canvas = document.getElementById('drawCanvas');
+  var ctx = canvas.getContext('2d');
+
+  // Render buffer to canvas
+  function render() {
+    var imgData = ctx.createImageData(W * SCALE, H * SCALE);
+    var d = imgData.data;
+    for (var y = 0; y < H; y++) {
+      var page = y >> 3;
+      var bit  = y & 7;
+      for (var x = 0; x < W; x++) {
+        var on = (buf[page * W + x] >> bit) & 1;
+        var c = on ? 255 : 0;
+        for (var sy = 0; sy < SCALE; sy++) {
+          for (var sx = 0; sx < SCALE; sx++) {
+            var px = ((y * SCALE + sy) * W * SCALE + (x * SCALE + sx)) * 4;
+            d[px] = c; d[px+1] = c; d[px+2] = c; d[px+3] = 255;
+          }
+        }
+      }
+    }
+    ctx.putImageData(imgData, 0, 0);
+  }
+
+  // Set or clear pixel at OLED coords
+  function setPixel(ox, oy, on) {
+    if (ox < 0 || ox >= W || oy < 0 || oy >= H) return;
+    var mask = 1 << (oy & 7);
+    if (on) buf[(oy >> 3) * W + ox] |= mask;
+    else    buf[(oy >> 3) * W + ox] &= ~mask;
+  }
+
+  // Bresenham line
+  function drawLine(x0, y0, x1, y1, on) {
+    var dx = Math.abs(x1 - x0), sx = x0 < x1 ? 1 : -1;
+    var dy = -Math.abs(y1 - y0), sy = y0 < y1 ? 1 : -1;
+    var err = dx + dy;
+    for (;;) {
+      setPixel(x0, y0, on);
+      if (x0 === x1 && y0 === y1) break;
+      var e2 = 2 * err;
+      if (e2 >= dy) { err += dy; x0 += sx; }
+      if (e2 <= dx) { err += dx; y0 += sy; }
+    }
+  }
+
+  // Convert pointer position to OLED coords
+  function toOled(e) {
+    var r = canvas.getBoundingClientRect();
+    var s = e.touches ? e.touches[0] : e;
+    return {
+      x: Math.min(W - 1, Math.max(0, Math.floor((s.clientX - r.left) * W / r.width))),
+      y: Math.min(H - 1, Math.max(0, Math.floor((s.clientY - r.top)  * H / r.height)))
+    };
+  }
+
+  // POST buffer to /api/draw
+  function sendBuf() {
+    var xhr = new XMLHttpRequest();
+    xhr.open('POST', '/api/draw', true);
+    xhr.setRequestHeader('Content-Type', 'application/octet-stream');
+    xhr.onload = function () {
+      if (xhr.status !== 200) showDrawMsg('Send failed', 'error');
+    };
+    xhr.onerror = function () { showDrawMsg('Connection lost', 'error'); };
+    xhr.send(buf.buffer.slice(0));
+  }
+
+  function showDrawMsg(text, type) {
+    var msg = document.getElementById('drawMsg');
+    msg.className = 'msg ' + (type || 'ok');
+    msg.textContent = text;
+    msg.style.display = 'block';
+    clearTimeout(msg._t);
+    msg._t = setTimeout(function () { msg.style.display = 'none'; }, 2000);
+  }
+
+  function scheduleLive() {
+    if (!_liveMode) return;
+    clearTimeout(_liveTimer);
+    _liveTimer = setTimeout(sendBuf, 80);
+  }
+
+  var _lastX = -1, _lastY = -1;
+
+  function onDown(e) {
+    e.preventDefault();
+    isDown = true;
+    var p = toOled(e);
+    _lastX = p.x; _lastY = p.y;
+    setPixel(p.x, p.y, tool !== 'eraser');
+    render();
+    scheduleLive();
+  }
+
+  function onMove(e) {
+    if (!isDown) return;
+    e.preventDefault();
+    var p = toOled(e);
+    if (_lastX < 0) { _lastX = p.x; _lastY = p.y; }
+    drawLine(_lastX, _lastY, p.x, p.y, tool !== 'eraser');
+    _lastX = p.x; _lastY = p.y;
+    render();
+    scheduleLive();
+  }
+
+  function onUp() {
+    isDown = false;
+    _lastX = -1; _lastY = -1;
+  }
+
+  canvas.addEventListener('mousedown',  onDown);
+  canvas.addEventListener('mousemove',  onMove);
+  canvas.addEventListener('mouseup',    onUp);
+  canvas.addEventListener('mouseleave', onUp);
+  canvas.addEventListener('touchstart', onDown, { passive: false });
+  canvas.addEventListener('touchmove',  onMove, { passive: false });
+  canvas.addEventListener('touchend',   onUp);
+  canvas.addEventListener('contextmenu', function (e) { e.preventDefault(); });
+
+  var btnPen    = document.getElementById('btnPen');
+  var btnEraser = document.getElementById('btnEraser');
+  var btnLive   = document.getElementById('btnLive');
+  var btnSend   = document.getElementById('btnDrawSend');
+  var btnClear  = document.getElementById('btnDrawClear');
+
+  function setTool(t) {
+    tool = t;
+    btnPen.classList.toggle('active', t === 'pen');
+    btnEraser.classList.toggle('active', t === 'eraser');
+  }
+  setTool('pen');
+
+  btnPen.addEventListener('click', function () { setTool('pen'); });
+  btnEraser.addEventListener('click', function () { setTool('eraser'); });
+
+  btnLive.addEventListener('click', function () {
+    _liveMode = !_liveMode;
+    btnLive.classList.toggle('active', _liveMode);
+    btnLive.textContent = _liveMode ? 'Live ON' : 'Live';
+  });
+
+  btnSend.addEventListener('click', function () {
+    sendBuf();
+    showDrawMsg('Sent!', 'ok');
+  });
+
+  btnClear.addEventListener('click', function () {
+    buf.fill(0);
+    render();
+    fetch('/api/draw?clear=1', { method: 'POST' });
+  });
+
+  render(); // initial blank frame
+})();

--- a/firmware/data/script.js
+++ b/firmware/data/script.js
@@ -696,7 +696,6 @@ pollCurrent();
 
 // Live drawing to OLED (Draw card)
 (function () {
-  var SCALE = 4;
   var W = 128, H = 64;
   // U8G2 page-addressed buffer: buf[page*128 + col], bit=(row%8); bit=1 → white pixel
   var buf = new Uint8Array(1024);
@@ -708,25 +707,53 @@ pollCurrent();
   var canvas = document.getElementById('drawCanvas');
   var ctx = canvas.getContext('2d');
 
-  // Render buffer to canvas
+  // Pre-allocate one ImageData at OLED native resolution (128×64).
+  // CSS width:100% + image-rendering:pixelated handles the visual upscaling.
+  var imgData = ctx.createImageData(W, H);
+  // Uint32Array view for fast RGBA writes (little-endian: 0xFFFFFFFF = white, 0xFF000000 = black)
+  var u32 = new Uint32Array(imgData.data.buffer);
+  var WHITE = 0xFFFFFFFF;
+  var BLACK = 0xFF000000;
+
+  // Dirty-row tracking: only putImageData over the rows that actually changed.
+  var dirtyMin = H, dirtyMax = -1;
+  function markDirty(y) {
+    if (y < dirtyMin) dirtyMin = y;
+    if (y > dirtyMax) dirtyMax = y;
+  }
+  function resetDirty() { dirtyMin = H; dirtyMax = -1; }
+
+  // Render only dirty rows to canvas
   function render() {
-    var imgData = ctx.createImageData(W * SCALE, H * SCALE);
-    var d = imgData.data;
+    if (dirtyMin > dirtyMax) return; // nothing changed
+    for (var y = dirtyMin; y <= dirtyMax; y++) {
+      var page = y >> 3;
+      var bit  = y & 7;
+      for (var x = 0; x < W; x++) {
+        u32[y * W + x] = (buf[page * W + x] >> bit) & 1 ? WHITE : BLACK;
+      }
+    }
+    // putImageData(data, dx, dy, dirtyX, dirtyY, w, h):
+    // dx/dy shift the entire imageData in canvas space; dirtyX/Y select which
+    // rows of the imageData to paint. Using dy=dirtyMin would shift the data
+    // DOWN by dirtyMin pixels BEFORE painting, so imageData row Y would land
+    // at canvas row Y+dirtyMin — doubling the offset. Keep dx=dy=0 and let
+    // the dirtyY argument alone control which rows are copied.
+    ctx.putImageData(imgData, 0, 0, 0, dirtyMin, W, dirtyMax - dirtyMin + 1);
+    resetDirty();
+  }
+
+  // Full redraw (used after clear / receive)
+  function renderAll() {
     for (var y = 0; y < H; y++) {
       var page = y >> 3;
       var bit  = y & 7;
       for (var x = 0; x < W; x++) {
-        var on = (buf[page * W + x] >> bit) & 1;
-        var c = on ? 255 : 0;
-        for (var sy = 0; sy < SCALE; sy++) {
-          for (var sx = 0; sx < SCALE; sx++) {
-            var px = ((y * SCALE + sy) * W * SCALE + (x * SCALE + sx)) * 4;
-            d[px] = c; d[px+1] = c; d[px+2] = c; d[px+3] = 255;
-          }
-        }
+        u32[y * W + x] = (buf[page * W + x] >> bit) & 1 ? WHITE : BLACK;
       }
     }
     ctx.putImageData(imgData, 0, 0);
+    resetDirty();
   }
 
   // Set or clear pixel at OLED coords
@@ -735,6 +762,7 @@ pollCurrent();
     var mask = 1 << (oy & 7);
     if (on) buf[(oy >> 3) * W + ox] |= mask;
     else    buf[(oy >> 3) * W + ox] &= ~mask;
+    markDirty(oy);
   }
 
   // Bresenham line
@@ -854,9 +882,9 @@ pollCurrent();
 
   btnClear.addEventListener('click', function () {
     buf.fill(0);
-    render();
+    renderAll();
     fetch('/api/draw?clear=1', { method: 'POST' });
   });
 
-  render(); // initial blank frame
+  renderAll(); // initial blank frame
 })();

--- a/firmware/data/style.css
+++ b/firmware/data/style.css
@@ -672,6 +672,57 @@ body {
 }
 .footer a:hover { color: var(--red-light); }
 
+/* Live draw canvas */
+.draw-tools {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 10px;
+  align-items: center;
+}
+.btn-tool {
+  padding: 6px 14px;
+  border: 1px solid var(--border);
+  background: var(--bg-accent);
+  color: var(--text-secondary);
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: .78em;
+  font-weight: 600;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  transition: background .15s, border-color .15s, color .15s;
+  font-family: inherit;
+}
+.btn-tool:hover {
+  background: var(--bg-hover);
+  border-color: var(--red);
+  color: var(--text-primary);
+}
+.btn-tool.active {
+  background: var(--red);
+  border-color: var(--red);
+  color: #fff;
+}
+.draw-canvas-wrap {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+  margin-bottom: 10px;
+  background: #000;
+  line-height: 0;
+  touch-action: none;
+}
+.draw-canvas-wrap canvas {
+  display: block;
+  width: 100%;
+  height: auto;
+  image-rendering: pixelated;
+  image-rendering: -moz-crisp-edges;
+  cursor: crosshair;
+}
+
 /* Responsive: narrow viewports (e.g. small phones) */
 @media (max-width: 380px) {
   body {

--- a/firmware/lib/web_dashboard/web_dashboard.cpp
+++ b/firmware/lib/web_dashboard/web_dashboard.cpp
@@ -9,6 +9,12 @@
 #include <esp_system.h>
 #endif
 
+// Draw to OLED -- shared state defined in app_state.cpp
+extern uint8_t           drawBuffer[1024];
+extern volatile bool     drawBufferDirty;
+extern volatile bool     drawModeActive;
+extern SemaphoreHandle_t displayMutex;
+
 // ==========================================================================
 //  Upload state
 // ==========================================================================
@@ -16,6 +22,13 @@
 static File   _uploadFile;
 static bool   _uploadOk    = false;
 static String _uploadError;
+
+// ==========================================================================
+//  Draw-to-OLED body accumulation
+// ==========================================================================
+
+static uint8_t _drawBodyBuf[1024];
+static size_t  _drawBodyLen = 0;
 
 // ==========================================================================
 //  Path sanitization (prevent path traversal)
@@ -307,10 +320,12 @@ static void handleDelete(AsyncWebServerRequest *request) {
 // ==========================================================================
 
 static void handleGetSettings(AsyncWebServerRequest *request) {
-    StaticJsonDocument<128> doc;
+    StaticJsonDocument<192> doc;
     doc["speed"]      = getPlaybackSpeed();
     doc["brightness"] = getDisplayBrightness();
     doc["volume"]     = getBuzzerVolume();
+    doc["flip"]       = getFlipMode();
+    doc["negative"]   = getNegativeGif();
     String json;
     serializeJson(doc, json);
     request->send(200, "application/json", json);
@@ -328,6 +343,12 @@ static void handlePostSettings(AsyncWebServerRequest *request) {
     if (request->hasParam("volume")) {
         int v = request->getParam("volume")->value().toInt();
         if (v >= 0 && v <= 100) setBuzzerVolume((uint8_t)v);
+    }
+    if (request->hasParam("flip")) {
+        setFlipMode(request->getParam("flip")->value() == "1");
+    }
+    if (request->hasParam("negative")) {
+        setNegativeGif(request->getParam("negative")->value() == "1");
     }
     // If save=1 is passed, persist to NVS
     if (request->hasParam("save")) {
@@ -554,6 +575,47 @@ static void handlePostTimezone(AsyncWebServerRequest *request) {
 }
 
 // ==========================================================================
+//  Handlers -- Draw to OLED
+// ==========================================================================
+
+static void handleDrawBody(AsyncWebServerRequest *request,
+                           uint8_t *data, size_t len,
+                           size_t index, size_t total) {
+    (void)total;
+    if (index == 0) _drawBodyLen = 0;
+    if (index + len > sizeof(_drawBodyBuf)) {
+        if (index >= sizeof(_drawBodyBuf)) return;
+        len = sizeof(_drawBodyBuf) - index;
+    }
+    memcpy(_drawBodyBuf + index, data, len);
+    _drawBodyLen += len;
+}
+
+static void handleDrawDone(AsyncWebServerRequest *request) {
+    // ?clear=1 -- exit draw mode, resume GIF playback
+    if (request->hasParam("clear")) {
+        drawModeActive  = false;
+        drawBufferDirty = false;
+        request->send(200, "application/json", "{\"ok\":true,\"cleared\":true}");
+        return;
+    }
+    // Body must be exactly 1024 bytes (128x64 / 8)
+    if (_drawBodyLen != 1024) {
+        request->send(400, "application/json", "{\"error\":\"Expected 1024 bytes\"}");
+        return;
+    }
+    if (xSemaphoreTake(displayMutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+        memcpy(drawBuffer, _drawBodyBuf, 1024);
+        xSemaphoreGive(displayMutex);
+    } else {
+        memcpy(drawBuffer, _drawBodyBuf, 1024);
+    }
+    drawModeActive  = true;
+    drawBufferDirty = true;
+    request->send(200, "application/json", "{\"ok\":true}");
+}
+
+// ==========================================================================
 //  Init
 // ==========================================================================
 
@@ -589,6 +651,7 @@ void webDashboardInit(AsyncWebServer &server) {
     server.on("/api/pins",          HTTP_POST, handlePostPins);
     server.on("/api/timezone",      HTTP_GET,  handleGetTimezone);
     server.on("/api/timezone",      HTTP_POST, handlePostTimezone);
+    server.on("/api/draw",          HTTP_POST, handleDrawDone, nullptr, handleDrawBody);
 
     // Catch-all: serve .qgif files from LittleFS for browser preview (path-normalized)
     server.onNotFound([](AsyncWebServerRequest *request) {

--- a/firmware/lib/web_dashboard/web_dashboard.cpp
+++ b/firmware/lib/web_dashboard/web_dashboard.cpp
@@ -1,4 +1,5 @@
 #include "web_dashboard.h"
+#include "app_state.h"
 #include "gif_player.h"
 #include <LittleFS.h>
 #include <ArduinoJson.h>
@@ -8,12 +9,6 @@
 #if defined(ESP32)
 #include <esp_system.h>
 #endif
-
-// Draw to OLED -- shared state defined in app_state.cpp
-extern uint8_t           drawBuffer[1024];
-extern volatile bool     drawBufferDirty;
-extern volatile bool     drawModeActive;
-extern SemaphoreHandle_t displayMutex;
 
 // ==========================================================================
 //  Upload state
@@ -27,7 +22,7 @@ static String _uploadError;
 //  Draw-to-OLED body accumulation
 // ==========================================================================
 
-static uint8_t _drawBodyBuf[1024];
+static uint8_t _drawBodyBuf[DRAW_BUFFER_SIZE];
 static size_t  _drawBodyLen = 0;
 
 // ==========================================================================
@@ -581,37 +576,51 @@ static void handlePostTimezone(AsyncWebServerRequest *request) {
 static void handleDrawBody(AsyncWebServerRequest *request,
                            uint8_t *data, size_t len,
                            size_t index, size_t total) {
-    (void)total;
-    if (index == 0) _drawBodyLen = 0;
-    if (index + len > sizeof(_drawBodyBuf)) {
-        if (index >= sizeof(_drawBodyBuf)) return;
-        len = sizeof(_drawBodyBuf) - index;
+    // Reject up-front if the declared Content-Length is wrong.
+    // This prevents a >DRAW_BUFFER_SIZE body being silently truncated to
+    // exactly DRAW_BUFFER_SIZE bytes and then passing the length check in
+    // handleDrawDone as if it were a valid frame.
+    if (total != DRAW_BUFFER_SIZE) {
+        // Drain remaining chunks so AsyncWebServer doesn't stall, but do
+        // not accumulate anything — handleDrawDone will reject via _drawBodyLen.
+        if (index == 0) _drawBodyLen = 0;
+        return;
     }
+    if (index == 0) _drawBodyLen = 0;
+    if (index + len > sizeof(_drawBodyBuf)) return; // should never happen given total check above
     memcpy(_drawBodyBuf + index, data, len);
     _drawBodyLen += len;
 }
 
 static void handleDrawDone(AsyncWebServerRequest *request) {
-    // ?clear=1 -- exit draw mode, resume GIF playback
+    // ?clear=1 -- signal the display task to leave DRAW_MODE.
+    // Setting drawModeActive=false is picked up by the DRAW_MODE tick in
+    // display_task.cpp, which calls enterState(GIF_PLAYBACK) within one loop
+    // iteration (~5 ms). drawBufferDirty is also cleared so a stale dirty flag
+    // from the previous frame cannot re-enter draw mode before the transition.
     if (request->hasParam("clear")) {
         drawModeActive  = false;
         drawBufferDirty = false;
         request->send(200, "application/json", "{\"ok\":true,\"cleared\":true}");
         return;
     }
-    // Body must be exactly 1024 bytes (128x64 / 8)
-    if (_drawBodyLen != 1024) {
-        request->send(400, "application/json", "{\"error\":\"Expected 1024 bytes\"}");
+    // Body must be exactly DRAW_BUFFER_SIZE bytes (128×64 / 8).
+    // _drawBodyLen will be 0 (not DRAW_BUFFER_SIZE) when handleDrawBody
+    // rejected the request due to a wrong Content-Length, so this check
+    // catches both an incorrect total and a genuinely short transfer.
+    if (_drawBodyLen != DRAW_BUFFER_SIZE) {
+        request->send(400, "application/json", "{\"error\":\"Expected exactly 1024 bytes\"}");
         return;
     }
-    if (xSemaphoreTake(displayMutex, pdMS_TO_TICKS(50)) == pdTRUE) {
-        memcpy(drawBuffer, _drawBodyBuf, 1024);
-        xSemaphoreGive(displayMutex);
+    if (xSemaphoreTake(drawBufferMutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+        memcpy(drawBuffer, _drawBodyBuf, DRAW_BUFFER_SIZE);
+        drawModeActive  = true;
+        drawBufferDirty = true;
+        xSemaphoreGive(drawBufferMutex);
     } else {
-        memcpy(drawBuffer, _drawBodyBuf, 1024);
+        request->send(503, "application/json", "{\"error\":\"busy\"}");
+        return;
     }
-    drawModeActive  = true;
-    drawBufferDirty = true;
     request->send(200, "application/json", "{\"ok\":true}");
 }
 

--- a/firmware/lib/web_dashboard/web_dashboard.h
+++ b/firmware/lib/web_dashboard/web_dashboard.h
@@ -22,6 +22,8 @@
 //   POST /api/settings?save=1 -- also persist current settings to NVS
 //   GET  /api/timezone       -- JSON {timezone, offset}
 //   POST /api/timezone?tz=   -- set timezone IANA name
+//   POST /api/draw            -- push 1024-byte U8G2 buffer to OLED (enters draw mode)
+//   POST /api/draw?clear=1   -- clear draw mode, resume GIF playback
 void webDashboardInit(AsyncWebServer &server);
 
 // Settings callbacks -- implemented by settings.cpp / display_helpers.cpp.
@@ -32,6 +34,10 @@ extern uint8_t  getDisplayBrightness();
 extern void     setBuzzerVolume(uint8_t pct);
 extern uint8_t  getBuzzerVolume();
 extern void     saveSettings();
+extern bool     getFlipMode();
+extern void     setFlipMode(bool val);
+extern bool     getNegativeGif();
+extern void     setNegativeGif(bool val);
 
 // Device identity -- implemented by settings.cpp.
 extern String getDeviceId();

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -16,6 +16,7 @@ board = seeed_xiao_esp32c3
 framework = arduino
 build_flags =
     -Iinclude
+    -Isrc
     -Isrc/games
     -Isrc/games/flappy_bird
     -Isrc/games/trex_runner

--- a/firmware/src/app_state.cpp
+++ b/firmware/src/app_state.cpp
@@ -21,3 +21,7 @@ const char *kQbitVersion = (QBIT_VERSION[0] != '\0')
 
 volatile bool updateAvailable = false;
 char         updateAvailableVersion[UPDATE_AVAILABLE_VERSION_LEN] = "";
+
+uint8_t       drawBuffer[DRAW_BUFFER_SIZE] = {};
+volatile bool drawBufferDirty = false;
+volatile bool drawModeActive  = false;

--- a/firmware/src/app_state.cpp
+++ b/firmware/src/app_state.cpp
@@ -22,6 +22,7 @@ const char *kQbitVersion = (QBIT_VERSION[0] != '\0')
 volatile bool updateAvailable = false;
 char         updateAvailableVersion[UPDATE_AVAILABLE_VERSION_LEN] = "";
 
-uint8_t       drawBuffer[DRAW_BUFFER_SIZE] = {};
-volatile bool drawBufferDirty = false;
-volatile bool drawModeActive  = false;
+uint8_t           drawBuffer[DRAW_BUFFER_SIZE] = {};
+volatile bool     drawBufferDirty = false;
+volatile bool     drawModeActive  = false;
+SemaphoreHandle_t drawBufferMutex = nullptr;

--- a/firmware/src/app_state.h
+++ b/firmware/src/app_state.h
@@ -35,7 +35,8 @@ enum DisplayState {
     TREX_RUNNING,
     TREX_OVER,
     FLAPPY_RUNNING,
-    FLAPPY_OVER
+    FLAPPY_OVER,
+    DRAW_MODE
 };
 
 // ==========================================================================
@@ -149,5 +150,13 @@ extern const char *kQbitVersion;
 #define UPDATE_AVAILABLE_VERSION_LEN 16
 extern volatile bool    updateAvailable;
 extern char             updateAvailableVersion[UPDATE_AVAILABLE_VERSION_LEN];
+
+// ==========================================================================
+//  Live draw buffer (web UI → OLED, 128×64 @ 1bpp U8G2 page format)
+// ==========================================================================
+#define DRAW_BUFFER_SIZE 1024
+extern uint8_t           drawBuffer[DRAW_BUFFER_SIZE];
+extern volatile bool     drawBufferDirty;
+extern volatile bool     drawModeActive;
 
 #endif // APP_STATE_H

--- a/firmware/src/app_state.h
+++ b/firmware/src/app_state.h
@@ -158,5 +158,6 @@ extern char             updateAvailableVersion[UPDATE_AVAILABLE_VERSION_LEN];
 extern uint8_t           drawBuffer[DRAW_BUFFER_SIZE];
 extern volatile bool     drawBufferDirty;
 extern volatile bool     drawModeActive;
+extern SemaphoreHandle_t drawBufferMutex;  // guards drawBuffer + drawBufferDirty
 
 #endif // APP_STATE_H

--- a/firmware/src/display_task.cpp
+++ b/firmware/src/display_task.cpp
@@ -420,6 +420,22 @@ void displayTask(void *param) {
         unsigned long now = millis();
         unsigned long elapsed = now - _stateEntryMs;
 
+        // --- Handle live draw buffer update (web UI → OLED) ---
+        if (drawModeActive && drawBufferDirty) {
+            drawBufferDirty = false;
+            if (_state != DRAW_MODE) {
+                enterState(DRAW_MODE);
+            }
+            if (xSemaphoreTake(displayMutex, pdMS_TO_TICKS(10)) == pdTRUE) {
+                memcpy(u8g2.getBufferPtr(), drawBuffer, DRAW_BUFFER_SIZE);
+                xSemaphoreGive(displayMutex);
+            } else {
+                memcpy(u8g2.getBufferPtr(), drawBuffer, DRAW_BUFFER_SIZE);
+            }
+            rotateBuffer180();
+            u8g2.sendBuffer();
+        }
+
         // --- Advance melody ---
         if (rtttl::isPlaying()) {
             rtttl::play();
@@ -911,6 +927,13 @@ void displayTask(void *param) {
                         enterState(GIF_PLAYBACK);
                     }
                     break;
+
+                case DRAW_MODE:
+                    if (gesture.type == SINGLE_TAP || gesture.type == LONG_PRESS) {
+                        drawModeActive = false;
+                        enterState(GIF_PLAYBACK);
+                    }
+                    break;
             }
         }
 
@@ -1189,6 +1212,10 @@ void displayTask(void *param) {
 
             case FLAPPY_OVER:
                 // Idle — waiting for gesture
+                break;
+
+            case DRAW_MODE:
+                // Idle — display is updated directly when drawBufferDirty is set
                 break;
 
             default:

--- a/firmware/src/display_task.cpp
+++ b/firmware/src/display_task.cpp
@@ -421,19 +421,21 @@ void displayTask(void *param) {
         unsigned long elapsed = now - _stateEntryMs;
 
         // --- Handle live draw buffer update (web UI → OLED) ---
+        // Hold drawBufferMutex for the entire read so the web task cannot
+        // write a new frame mid-copy. Clear drawBufferDirty only after the
+        // copy succeeds; if the mutex is unavailable, leave dirty=true and
+        // retry on the next tick.
         if (drawModeActive && drawBufferDirty) {
-            drawBufferDirty = false;
-            if (_state != DRAW_MODE) {
-                enterState(DRAW_MODE);
-            }
-            if (xSemaphoreTake(displayMutex, pdMS_TO_TICKS(10)) == pdTRUE) {
+            if (xSemaphoreTake(drawBufferMutex, pdMS_TO_TICKS(10)) == pdTRUE) {
                 memcpy(u8g2.getBufferPtr(), drawBuffer, DRAW_BUFFER_SIZE);
-                xSemaphoreGive(displayMutex);
-            } else {
-                memcpy(u8g2.getBufferPtr(), drawBuffer, DRAW_BUFFER_SIZE);
+                drawBufferDirty = false;
+                xSemaphoreGive(drawBufferMutex);
+                if (_state != DRAW_MODE) {
+                    enterState(DRAW_MODE);
+                }
+                rotateBuffer180();
+                u8g2.sendBuffer();
             }
-            rotateBuffer180();
-            u8g2.sendBuffer();
         }
 
         // --- Advance melody ---
@@ -1215,7 +1217,11 @@ void displayTask(void *param) {
                 break;
 
             case DRAW_MODE:
-                // Idle — display is updated directly when drawBufferDirty is set
+                // Exit to GIF playback when the web API clears draw mode
+                // (e.g. POST /api/draw?clear=1 sets drawModeActive=false).
+                if (!drawModeActive) {
+                    enterState(GIF_PLAYBACK);
+                }
                 break;
 
             default:

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -61,6 +61,7 @@ void setup() {
     connectivityBits  = xEventGroupCreate();
     displayMutex      = xSemaphoreCreateMutex();
     gifPlayerMutex    = xSemaphoreCreateMutex();
+    drawBufferMutex   = xSemaphoreCreateMutex();
 
     // 5. GIF player + idle animation
     gifPlayerInit(&u8g2);


### PR DESCRIPTION
## Summary

Two new features added to the qbit.local web dashboard:

1. Live Draw — paint directly on the OLED from the browser
2. Flip / GIF Invert toggles — expose the existing display orientation
   and negative-GIF settings through the Settings card


## Changes

### Live Draw canvas (POST /api/draw)

- New DRAW_MODE state added to the DisplayState enum (app_state.h/cpp)
- display_task: when drawBufferDirty is set, the 1 024-byte buffer is
  copied straight into the U8G2 framebuffer and sent to the OLED.
  Tap or long-press exits draw mode.
- web_dashboard: new POST /api/draw route accepts a 1 024-byte raw body
  (one bit per pixel, U8G2 page layout) and sets drawBufferDirty.
  POST /api/draw?clear=1 blanks the buffer.
- index.html: collapsible "Draw on OLED" card with a 512x256 canvas
  (4x scale), Pen/Eraser/Clear buttons, and a Live toggle that streams
  updates while drawing (80 ms debounce). Send button does a one-shot
  push.
- style.css / script.js: draw module with Bresenham line interpolation
  so fast mouse/touch strokes have no gaps.

### Flip Mode & GIF Invert toggles

- web_dashboard.h: added extern declarations for getFlipMode /
  setFlipMode / getNegativeGif / setNegativeGif.
- GET /api/settings now returns "flip" and "negative" boolean fields.
- POST /api/settings accepts flip=0|1 and negative=0|1 query params.
- Settings card in index.html has two new ON/OFF toggle buttons (same
  style as the existing Sound toggle).
- script.js initialises both toggles from the device state on page load
  and POSTs changes immediately on click.


## Testing

- Firmware compiled successfully: RAM 15.6 %, Flash 41.0 %
- Filesystem image and firmware uploaded and verified on device
  (Seeed XIAO ESP32-C3)