### PR TITLE
fix(frontend): remove unused sharp dependency to resolve libvips CVEs

### DIFF
--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -19,7 +19,6 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.0",
-    "sharp": "^0.33.0",
     "typescript": "^5.7.0",
     "vite": "^6.0.0"
   }


### PR DESCRIPTION
## What
Remove the unused `sharp` devDependency from `web/frontend/package.json`.

## Why
Dependabot alert #8 flags `sharp`'s inherited libvips vulnerabilities
(CVE-2026-33327, CVE-2026-33328, CVE-2026-35590, CVE-2026-35591 — High).

`sharp` was introduced in f6edcda for `scripts/generate-icons.js` (SVG→icon
generation via a `prebuild` hook). That script and its `prebuild` /
`generate-icons` npm scripts were removed in b56b708, but the `sharp`
devDependency was left behind. Nothing in the codebase imports it.

## Verification
- Repo-wide search: only reference was `package.json` (no imports, no scripts, no CI).
- `npm install && npm run build` in `node:20.18-alpine3.21` succeeds with `sharp` removed; `dist/` output unchanged and `sharp` no longer installed.

Closes Dependabot alert #8 on merge (no code imports sharp; build unaffected).
